### PR TITLE
Add midi_reload and deployment preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # cfc_midi_interface
-Serverside addon to enable MIDI interface
+This addon allows users with MIDI devices to play the [Playable Piano](https://steamcommunity.com/sharedfiles/filedetails/?id=104548572) addon with said device.  
+It also integrates Starfall hooks and functions for the MIDI devices and Playable Piano.  
+
+## Important
+Clients are required to have [gmcl_midi.dll](https://github.com/FPtje/gmcl_midi) in `garrysmod/lua/bin` for MIDI devices to be used.
+
+## Console Commands
+- `midi_devices` - This allows you to select the MIDI device you wish to use.
+- `midi_debug [0|1]` - This boolean ConVar enables/disables debug prints in console, which show information about midi events as they occur.
+- `midi_reload` - This simply reloads the addon, and searches for `gmcl_midi.dll` again, allowing users to add the file without relog.
+- `sv_midi_sf_note_quota` - This is a server-side quota for starfall playNote calls (per second) (def 30).
+
+## Starfall
+- The `MIDI` hook is now available on client-side, using the following syntax:  
+`nil GM:MIDI( float time, int command, int note, int velocity )`  
+or more often:  
+`hook.add("MIDI", "my_unique_identifier", function(time, command, note, velocity) end)`
+- Entities now have the `boolean Entity:IsInstrument()` and `boolean Entity:playNote(int note)` functions.  
+`Entity:playNote` takes a note index from `1-61` and returns a success boolean.  
+**NOTE:** `Entity:playNote` is limited by the `sv_midi_sf_note_quota` ConVar.  
+**NOTE2:** `Entity:playNote` also requires the calling player have PhysGun access to the instrument entity.
+

--- a/lua/autorun/client/cl_cfc_mi_init.lua
+++ b/lua/autorun/client/cl_cfc_mi_init.lua
@@ -1,3 +1,2 @@
--- We might wanna rename this
 CreateConVar( "sv_midi_sf_notes_quota", 30, FCVAR_REPLICATED + FCVAR_ARCHIVE + FCVAR_PROTECTED )
 include( "cfc_midi_interface/base.lua" )

--- a/lua/cfc_midi_interface/base.lua
+++ b/lua/cfc_midi_interface/base.lua
@@ -10,9 +10,11 @@ function cfc_midi.sendNote( instrument, note )
     if not instrument.OnRegisteredKeyPlayed then
         error( "Invalid instrument entity." )
     end
+
     if not cfc_midi.MIDIKeys[note] then
         error( "Note out of range. ( 1-" .. #cfc_midi.MIDIKeys .. " )" )
     end
+
     instrument:OnRegisteredKeyPlayed( cfc_midi.MIDIKeys[note] )
     net.Start( "InstrumentNetwork" )
         net.WriteEntity( instrument )
@@ -26,15 +28,19 @@ local function printPre( addNewl, ... )
     local d = {...}
     local last = #d
     local out = {}
+
     for k, v in ipairs( d ) do
         table.insert( out, tostring( v ) )
+
         if k ~= last then
             table.insert( out, "\t" )
         end
     end
+    
     if addNewl then
         table.insert( out, "\n" )
     end
+
     return unpack( out )
 end
 
@@ -52,6 +58,7 @@ function cfc_midi.load()
     if file.Exists( "lua/bin/gmcl_midi_win32.dll", "MOD" ) or file.Exists( "lua/bin/gmcl_midi_linux.dll", "MOD" ) then
         cfc_midi.print( "GMCL-Module detected!" )
         require( "midi" ) -- Import the library
+
         if not midi then -- Check it succeeded
             print( "GMCL-Module failed to initialize." )
             return

--- a/lua/cfc_midi_interface/base.lua
+++ b/lua/cfc_midi_interface/base.lua
@@ -36,7 +36,7 @@ local function printPre( addNewl, ... )
             table.insert( out, "\t" )
         end
     end
-    
+
     if addNewl then
         table.insert( out, "\n" )
     end

--- a/lua/cfc_midi_interface/base.lua
+++ b/lua/cfc_midi_interface/base.lua
@@ -47,57 +47,61 @@ function cfc_midi.printChat( ... )
     chat.AddText( Color( 0, 255, 255 ), "MIDI: ", Color( 220, 220, 220 ), printPre( false, ... ) )
 end
 
--- If file exists ( windows or linux )
-if file.Exists( "lua/bin/gmcl_midi_win32.dll", "MOD" ) or file.Exists( "lua/bin/gmcl_midi_linux.dll", "MOD" ) then
-    cfc_midi.print( "GMCL-Module detected!" )
-    require( "midi" ) -- Import the library
-    if not midi then -- Check it succeeded
-        print( "GMCL-Module failed to initialize." )
-        return
-    end
-    cfc_midi.printChat( "GMCL-Module initialised. Use console commands midi_devices and midi_debug [0|1] to use." )
+function cfc_midi.load()
+    -- If file exists ( windows or linux )
+    if file.Exists( "lua/bin/gmcl_midi_win32.dll", "MOD" ) or file.Exists( "lua/bin/gmcl_midi_linux.dll", "MOD" ) then
+        cfc_midi.print( "GMCL-Module detected!" )
+        require( "midi" ) -- Import the library
+        if not midi then -- Check it succeeded
+            print( "GMCL-Module failed to initialize." )
+            return
+        end
+        cfc_midi.printChat( "GMCL-Module initialised. Use console commands midi_devices and midi_debug [0|1] to use." )
 
-    -- Connect to first device if it exists for convenience
-    local ports = midi.GetPorts()
-    local portsCount = table.Count( ports )
-    if portsCount > 0 then
-        midi.Open( 0 )
-        cfc_midi.print( "Connected to device " .. ports[0] )
-    end
-
-    hook.Add( "MIDI", "midiPlayablePiano", function( time, command, note, velocity, ... )
-        local code = midi.GetCommandCode( command )
-        local name = midi.GetCommandName( command )
-        if name == "NOTE_ON" and velocity == 0 then
-            name = "NOTE_OFF"
+        -- Connect to first device if it exists for convenience
+        local ports = midi.GetPorts()
+        local portsCount = table.Count( ports )
+        if portsCount > 0 then
+            midi.Open( 0 )
+            cfc_midi.print( "Connected to device " .. ports[0] )
         end
 
-        -- Do debug print if enabled
-        local cVar = GetConVar( "midi_debug" )
-        if cVar and cVar:GetBool() then
-            -- The code is a byte ( number between 0 and 254 ).
-            cfc_midi.print( " = == EVENT = = =" )
-            cfc_midi.print( "Time:\t", time )
-            cfc_midi.print( "Code:\t", code )
-            cfc_midi.print( "Channel:\t", midi.GetCommandChannel( command ) )
-            cfc_midi.print( "Name:\t", name )
-            cfc_midi.print( "Parameters", note, velocity, ... )
-        end
+        hook.Add( "MIDI", "midiPlayablePiano", function( time, command, note, velocity, ... )
+            local code = midi.GetCommandCode( command )
+            local name = midi.GetCommandName( command )
+            if name == "NOTE_ON" and velocity == 0 then
+                name = "NOTE_OFF"
+            end
 
-        -- Get instrument entity
-        local instrument = LocalPlayer().Instrument
-        if not IsValid( instrument ) then return end
+            -- Do debug print if enabled
+            local cVar = GetConVar( "midi_debug" )
+            if cVar and cVar:GetBool() then
+                -- The code is a byte ( number between 0 and 254 ).
+                cfc_midi.print( " = == EVENT = = =" )
+                cfc_midi.print( "Time:\t", time )
+                cfc_midi.print( "Code:\t", code )
+                cfc_midi.print( "Channel:\t", midi.GetCommandChannel( command ) )
+                cfc_midi.print( "Name:\t", name )
+                cfc_midi.print( "Parameters", note, velocity, ... )
+            end
 
-        -- Increase max keys ( previously 4 ) so you can play something good
-        instrument.MaxKeys = 10
+            -- Get instrument entity
+            local instrument = LocalPlayer().Instrument
+            if not IsValid( instrument ) then return end
 
-        -- Zero velocity NOTE_ON substitutes NOTE_OFF
-        if not midi or name ~= "NOTE_ON" then return end
-        if velocity == 0 or not cfc_midi.MIDIKeys or not cfc_midi.MIDIKeys[note - 35] then return end
+            -- Increase max keys ( previously 4 ) so you can play something good
+            instrument.MaxKeys = 10
 
-        cfc_midi.sendNote( instrument, note - 35 )
-    end )
+            -- Zero velocity NOTE_ON substitutes NOTE_OFF
+            if not midi or name ~= "NOTE_ON" then return end
+            if velocity == 0 or not cfc_midi.MIDIKeys or not cfc_midi.MIDIKeys[note - 35] then return end
 
-    -- Tell others it worked
-    hook.Run( "cfc_midi_init", midi )
+            cfc_midi.sendNote( instrument, note - 35 )
+        end )
+
+        -- Tell others it worked
+        hook.Run( "cfc_midi_init", midi )
+    end
 end
+
+cfc_midi.load()

--- a/lua/cfc_midi_interface/console.lua
+++ b/lua/cfc_midi_interface/console.lua
@@ -20,6 +20,11 @@ local function midiClose()
     end
 end
 
+concommand.Add( "midi_reload", function( ply, cmd, args )
+    cfc_midi.print("Reloading...")
+    cfc_midi.load()
+end )
+
 hook.Add( "cfc_midi_init", "cfc_midi_console", function( _midi )
     midi = _midi
 

--- a/lua/cfc_midi_interface/console.lua
+++ b/lua/cfc_midi_interface/console.lua
@@ -32,8 +32,10 @@ hook.Add( "cfc_midi_init", "cfc_midi_console", function( _midi )
     concommand.Add( "midi_devices", function( ply, cmd, args )
         local ports = midi.GetPorts()
         local portsCount = table.Count( ports )
+
         if portsCount > 0 then
             cfc_midi.print( "Opening menu..." )
+            
             Derma_Query( "Which device you would like to use?" .. ( portsCount > 3 and " ( Max. 3 devices )" or "" ),
                 "Device selection",
                 "Disable", midiClose(),

--- a/lua/cfc_midi_interface/console.lua
+++ b/lua/cfc_midi_interface/console.lua
@@ -35,7 +35,7 @@ hook.Add( "cfc_midi_init", "cfc_midi_console", function( _midi )
 
         if portsCount > 0 then
             cfc_midi.print( "Opening menu..." )
-            
+
             Derma_Query( "Which device you would like to use?" .. ( portsCount > 3 and " ( Max. 3 devices )" or "" ),
                 "Device selection",
                 "Disable", midiClose(),

--- a/lua/cfc_midi_interface/starfall_midi.lua
+++ b/lua/cfc_midi_interface/starfall_midi.lua
@@ -47,7 +47,7 @@ hook.Add( "Initialize", "MIDI_SF", function()
         if not ent.OnRegisteredKeyPlayed then
             error( "Entity is not an instrument." )
         end
-        
+
         if FPP then
             if not FPP.canTouchEnt( ent, "Physgun" ) then
                 error( "You do not have permission to send notes to this instrument" )


### PR DESCRIPTION
Adds a midi_reload console command so that users don't have to relog the server when adding the client side dll.
Include styling fixes, README, and other finalizing changes.